### PR TITLE
Get encoding for a string to fix JPN

### DIFF
--- a/license.plist
+++ b/license.plist
@@ -187,7 +187,7 @@ bloqueado, ou o arquivo pode estar bloqueado.</string>
 	</array>
 	<key>zh</key>
 	<array>
-		<integer>0</integer>
+		<integer>25</integer>
 		<string>Chinese</string>
 		<string>同意</string>
 		<string>反对</string>

--- a/main.c
+++ b/main.c
@@ -115,12 +115,16 @@ int main(int argc, char *argv[]) {
 		printf("'%s' dictionary strings error (should be 10 items)\n",isoch+1);
 		return 1;
 	}
-	UInt32 encoding = kTextEncodingMacRoman;
-	CFNumberRef enc = CFArrayGetValueAtIndex(strings, 0);
-	if (CFGetTypeID(enc)!=CFNumberGetTypeID()) {
-		printf("'%s' dictionary strings error (first item must be a number)\n",isoch+1);
-		return 1;
-	}
+	// We should get ID of encoding, for exaple Japanise language can be encoded with kTextEncodingMacJapanese
+   UInt32 encoding = kTextEncodingMacRoman;
+   CFNumberRef enc = CFArrayGetValueAtIndex(strings, 0);
+
+   if (!CFNumberGetValue(enc, kCFNumberSInt32Type, &encoding)){
+       printf("'%s' dictionary strings error (first item can't be convert to int)\n",isoch+1);
+       return 1;
+   };
+ 
+   printf("Detected: '%s (%s)', LangCode = %d, RegionCode = %d, Encoding = %d\n", argv[2],isoch+1,lang,region, encoding);
 //	Set up the STR* resource here. No worries about RAM, so we do a sufficiently large size,
 //	and whittle it down later.
 	Handle strsh = NewHandleClear(32768);
@@ -135,20 +139,8 @@ int main(int argc, char *argv[]) {
 			return 1;
 		}
 		if (!CFStringGetPascalString(s, p, 256, encoding)) {
-         // try retrieving string with Chinese encoding
-         bool success = CFStringGetPascalString(s, p, 256, kTextEncodingMacChineseSimp);
-         
-         // try retrieving string with Japanese encoding
-         if (!success)
-         {
-            success = CFStringGetPascalString(s, p, 256, kTextEncodingMacJapanese);
-         }
-         
-         if (!success)
-         {
-            printf("'%s' dictionary error (can't convert #%d to a Pascal string)\n",isoch+1,i);
-                        return 1;
-         }
+			printf("'%s' dictionary error (can't convert #%d to a Pascal string)\n",isoch+1,i);
+			return 1;
 		}
 		p += p[0]+1;
 	}


### PR DESCRIPTION
Checking for individual encodings didn't seem to be working for Japanese for some reason. Copied the code from https://github.com/pypt/dmg-add-license/pull/2 which seems to have fixed our ability to add Japanese in to the dmg.

This change uses the value of the encoding from the included plist, which is smarter than the several if statements I was using. The normal Roman encoding has a value of 0, Japanese is 1, and Chinese (Simplified) is 25